### PR TITLE
[BUG] Making 'GROUP BY' complaining valid SQL 

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -148,7 +148,7 @@ class Extension extends \Bolt\BaseExtension
 
             // the normal query
             $query = sprintf(
-                "SELECT COUNT(name) as count, slug, name FROM %s WHERE taxonomytype IN ('%s') GROUP BY name ORDER BY %s",
+                "SELECT COUNT(name) as count, slug, name FROM %s WHERE taxonomytype IN ('%s') GROUP BY name,slug,sortorder ORDER BY %s",
                 $tablename,
                 $name,
                 $sortorder


### PR DESCRIPTION
`ERROR:  column "bolt_taxonomy.slug" must appear in the GROUP BY clause or be used in an aggregate function at character 30`
`STATEMENT:  SELECT COUNT(name) as count, slug, name FROM bolt_taxonomy WHERE taxonomytype IN ('professions') GROUP BY name ORDER BY sortorder ASC`

This is with Postgresql because it follows SQL standard.