### PR TITLE
Check if `options` actually is not empty.

### DIFF
--- a/src/Twig/TaxonomyListExtension.php
+++ b/src/Twig/TaxonomyListExtension.php
@@ -159,7 +159,7 @@ class TaxonomyListExtension
             if ($rows && ($weighted || $limit)) {
                 // find the max / min for the results
                 $named['maxcount'] = 0;
-                $named['number_of_tags'] = count($named['options']);
+                $named['number_of_tags'] = !empty($named['options']) ? count($named['options']) : 0;
                 foreach ($rows as $row) {
                     if ($row['count']>=$named['maxcount']) {
                         $named['maxcount']= $row['count'];


### PR DESCRIPTION
Fixes error, if strict settings: 

![schermafbeelding 2017-10-06 om 10 05 00](https://user-images.githubusercontent.com/1833361/31268831-52c58f14-aa7e-11e7-908c-78ac447c1299.png)
